### PR TITLE
Updated the Dockerfile to update to the latest ca-certificates store

### DIFF
--- a/.devcontainer/application/Dockerfile
+++ b/.devcontainer/application/Dockerfile
@@ -1,5 +1,11 @@
 FROM ubuntu:20.04
 
+
+# == Get ca-certificates up to date ==
+RUN apt-get -y update
+RUN apt-get -y install ca-certificates
+
+
 # == Copy Data ==
 COPY install_scripts /install_scripts
 


### PR DESCRIPTION
Because of everything in https://we.phorge.it/T15051 and for additional reference 

There are various solutions to this issue, this one just updates the package inside the container

See https://stackoverflow.com/questions/69387175/git-for-windows-ssl-certificate-problem-certificate-has-expired for some background

